### PR TITLE
OR the high/low bits together

### DIFF
--- a/ADT7470.cpp
+++ b/ADT7470.cpp
@@ -421,7 +421,7 @@ uint16_t ADT7470::getReg16(uint8_t reg)
   uint8_t h, l;
   _read(reg, &l);
   _read(reg + 1, &h);
-  return (((uint16_t)h) << 8) & l;
+  return (((uint16_t)h) << 8) | l;
 }
 
 void ADT7470::setReg16(uint8_t reg, uint16_t val)


### PR DESCRIPTION
I was unable to read tach values. Was able to read raw registers but was not getting final values.

Noticed that the getReg16 was AND'ing instead of adding/OR'ing the bits together from high/low registers which was giving me constant '0' readings. Changing to OR got numbers to show up.

My numbers from the tach is still strange but that may be a configuration issue elsewhere on the chip.